### PR TITLE
feat: reuse the same established nomad tcp connexions

### DIFF
--- a/cmd/bootstrap_git.go
+++ b/cmd/bootstrap_git.go
@@ -37,6 +37,13 @@ var bootstrapGitCmd = &cobra.Command{
 	Long:  ``,
 	// Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		// Create Nomad client
+		client, err := nomad.NewClient()
+		if err != nil {
+			fmt.Printf("Error %s\n", err)
+		}
+
 		// Reconcile
 		for true {
 			repositoryURL, err := url.Parse(gitArgs.url)
@@ -59,12 +66,6 @@ var bootstrapGitCmd = &cobra.Command{
 			files, err := fs.ReadDir(path)
 			if err != nil {
 				return err
-			}
-
-			// Create Nomad client
-			client, err := nomad.NewClient()
-			if err != nil {
-				fmt.Printf("Error %s\n", err)
 			}
 
 			desiredStateJobs := make(map[string]interface{})


### PR DESCRIPTION
Hello,

I started to use this operator (experimental) and noticed that after some hours/days running, it's going to create/accumulate new connection and get some 429 rate limiting error from the nomad server (they recently added a maximum tcp connexion limited to 100 (configurable) from the same IP per default).

I applied the following patch on our running instance to reuse the same client and avoid this issue.

Thank you for initiating this project!