### PR TITLE
log path of job when it fails to parse

### DIFF
--- a/cmd/bootstrap_git.go
+++ b/cmd/bootstrap_git.go
@@ -87,7 +87,7 @@ var bootstrapGitCmd = &cobra.Command{
 				job, err := client.ParseJob(string(b))
 				if err != nil {
 					// If a parse error occurs we skip the job an continue with the next job
-					fmt.Println(err)
+					fmt.Printf("Failed to parse file [%s]: %s\n", filePath, err)
 					continue
 				}
 				desiredStateJobs[job.GetName()] = job


### PR DESCRIPTION
This should make it easy to debug when you have tons of files and trying to figure out why it doesn't parse correctly.