### PR TITLE
add support for replacing variable items value with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ Usage:
   nomoperator bootstrap fs [path] [flags]
 
 Flags:
-      --base-dir string   Path to the base directory (default "./")
-      --delete            Enable delete missing jobs
-  -h, --help              help for fs
-      --path string       glob pattern relative to the base-dir (default "**/*.nomad")
-      --var-path string   var glob pattern relative to the base-dir (default "**/*.vars.yml")
-      --watch             Enable watch mode
+      --base-dir string         Path to the base directory (default "./")
+      --delete                  Enable delete missing jobs
+  -h, --help                    help for fs
+      --path string             glob pattern relative to the base-dir (default "**/*.nomad")
+      --var-env-prefix string   prefix used for environment variable replacement (default "env:")
+      --var-path string         var glob pattern relative to the base-dir (default "**/*.vars.yml")
+      --watch                   Enable watch mode
 
 Global Flags:
-  -a, --address string   Address of the Nomad server
+  -a, --address string          Address of the Nomad server
 ```
 
 Use it like this:
@@ -62,6 +63,7 @@ Flags:
       --ssh-key string                 SSH private key
       --url string                     git repository URL
       --username string                SSH username (default "git")
+      --var-env-prefix string          prefix used for environment variable replacement (default "env:")
       --var-path string                var glob pattern relative to the repository root (default "**/*.vars.yml")
       --watch                          Enable watch mode (default true)
 
@@ -158,11 +160,27 @@ EOF
 
 ## Variables
 
-Variables are yml files. All keys and values in items should be of type string.
+Variables are yaml files. All keys and values in items should be of type string.
 
 ```yaml
 path: nomad/jobs/jobname
 items:
   key1: "value1"
   key2: "value2"
+```
+
+To replace a value for items in the variable files by an environment variable, use the prefix defined in `--var-env-prefix` which defaults to `env:`.
+This allows you to safely store variables without exposing sensitive information.
+
+```yaml
+path: nomad/jobs/jobname
+items:
+  username: "john"
+  password: "env:PASSWORD"
+```
+
+You can use tools such as [dotenvx](https://dotenvx.com) to store encrypted environment variables. Then run nomoperator with dotenvx. Refer to the dotenvx documentation for more information.
+
+```bash
+dotenvx run -- nomoperator bootstrap fs --base-dir /path/to/base/dir --path jobs/*.nomad
 ```

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Usage:
   nomoperator bootstrap fs [path] [flags]
 
 Flags:
-      --base-dir string         Path to the base directory (default "./")
-      --delete                  Enable delete missing jobs
-  -h, --help                    help for fs
-      --path string             glob pattern relative to the base-dir (default "**/*.nomad")
-      --var-env-prefix string   prefix used for environment variable replacement (default "env:")
-      --var-path string         var glob pattern relative to the base-dir (default "**/*.vars.yml")
-      --watch                   Enable watch mode
+      --base-dir string     Path to the base directory (default "./")
+      --delete              Enable delete missing jobs
+      --env-prefix string   prefix used for environment variable replacement (default "env:")
+  -h, --help                help for fs
+      --path string         glob pattern relative to the base-dir (default "**/*.nomad")
+      --var-path string     var glob pattern relative to the base-dir (default "**/*.vars.yml")
+      --watch               Enable watch mode
 
 Global Flags:
-  -a, --address string          Address of the Nomad server
+  -a, --address string   Address of the Nomad server
 ```
 
 Use it like this:
@@ -56,6 +56,7 @@ Usage:
 Flags:
       --branch string                  git branch (default "main")
       --delete                         Enable delete missing jobs (default true)
+      --env-prefix string              prefix used for environment variable replacement (default "env:")
   -h, --help                           help for git
       --password string                SSH private key password
       --path string                    glob pattern relative to the repository root (default "**/*.nomad")
@@ -63,7 +64,6 @@ Flags:
       --ssh-key string                 SSH private key
       --url string                     git repository URL
       --username string                SSH username (default "git")
-      --var-env-prefix string          prefix used for environment variable replacement (default "env:")
       --var-path string                var glob pattern relative to the repository root (default "**/*.vars.yml")
       --watch                          Enable watch mode (default true)
 
@@ -169,7 +169,7 @@ items:
   key2: "value2"
 ```
 
-To replace a value for items in the variable files by an environment variable, use the prefix defined in `--var-env-prefix` which defaults to `env:`.
+To replace a value for items in the variable files by an environment variable, use the prefix defined in `--env-prefix` which defaults to `env:`.
 This allows you to safely store variables without exposing sensitive information.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Usage:
   nomoperator bootstrap fs [path] [flags]
 
 Flags:
-      --base-dir string     Path to the base directory (default "./")
-      --delete              Enable delete missing jobs
-      --env-prefix string   prefix used for environment variable replacement (default "env:")
-  -h, --help                help for fs
-      --path string         glob pattern relative to the base-dir (default "**/*.nomad")
-      --var-path string     var glob pattern relative to the base-dir (default "**/*.vars.yml")
-      --watch               Enable watch mode
+      --base-dir string       Path to the base directory (default "./")
+      --delete                Enable delete missing jobs
+      --env-template string   template used for environment variable replacement (default "<<\\$env\\(([A-Z0-9_]+)\\)>>")
+  -h, --help                  help for fs
+      --path string           glob pattern relative to the base-dir (default "**/*.nomad")
+      --var-path string       var glob pattern relative to the base-dir (default "**/*.vars.yml")
+      --watch                 Enable watch mode
 
 Global Flags:
   -a, --address string   Address of the Nomad server
@@ -56,7 +56,7 @@ Usage:
 Flags:
       --branch string                  git branch (default "main")
       --delete                         Enable delete missing jobs (default true)
-      --env-prefix string              prefix used for environment variable replacement (default "env:")
+      --env-template string            template used for environment variable replacement (default "<<\\$env\\(([A-Z0-9_]+)\\)>>")
   -h, --help                           help for git
       --password string                SSH private key password
       --path string                    glob pattern relative to the repository root (default "**/*.nomad")
@@ -169,14 +169,13 @@ items:
   key2: "value2"
 ```
 
-To replace a value for items in the variable files by an environment variable, use the prefix defined in `--env-prefix` which defaults to `env:`.
-This allows you to safely store variables without exposing sensitive information.
+To replace a value for items in the variable files by an environment variable, use the prefix defined in `--env-template` which defaults to `<<$env(VARIABLE)>>`.
 
 ```yaml
 path: nomad/jobs/jobname
 items:
   username: "john"
-  password: "env:PASSWORD"
+  password: "<<$env(PASSWORD)>>"
 ```
 
 You can use tools such as [dotenvx](https://dotenvx.com) to store encrypted environment variables. Then run nomoperator with dotenvx. Refer to the dotenvx documentation for more information.

--- a/cmd/bootstrap_fs.go
+++ b/cmd/bootstrap_fs.go
@@ -9,12 +9,12 @@ import (
 )
 
 type fsFlags struct {
-	base_dir       string
-	path           string
-	var_path       string
-	var_env_prefix string
-	watch          bool
-	delete         bool
+	base_dir   string
+	path       string
+	var_path   string
+	env_prefix string
+	watch      bool
+	delete     bool
 }
 
 var fsArgs fsFlags
@@ -24,7 +24,7 @@ func init() {
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.base_dir, "base-dir", "./", "Path to the base directory")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.path, "path", "**/*.nomad", "glob pattern relative to the base-dir")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the base-dir")
-	bootstrapFsCmd.Flags().StringVar(&fsArgs.var_env_prefix, "var-env-prefix", "env:", "prefix used for environment variable replacement")
+	bootstrapFsCmd.Flags().StringVar(&fsArgs.env_prefix, "env-prefix", "env:", "prefix used for environment variable replacement")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.watch, "watch", false, "Enable watch mode")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.delete, "delete", false, "Enable delete missing jobs")
 }
@@ -35,11 +35,11 @@ var bootstrapFsCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:         fsArgs.path,
-			VarPath:      fsArgs.var_path,
-			VarEnvPrefix: fsArgs.var_env_prefix,
-			Watch:        fsArgs.watch,
-			Delete:       fsArgs.delete,
+			Path:      fsArgs.path,
+			VarPath:   fsArgs.var_path,
+			EnvPrefix: fsArgs.env_prefix,
+			Watch:     fsArgs.watch,
+			Delete:    fsArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				fs := osfs.New(fsArgs.base_dir)
 				return fs, nil

--- a/cmd/bootstrap_fs.go
+++ b/cmd/bootstrap_fs.go
@@ -9,12 +9,12 @@ import (
 )
 
 type fsFlags struct {
-	base_dir   string
-	path       string
-	var_path   string
-	env_prefix string
-	watch      bool
-	delete     bool
+	base_dir     string
+	path         string
+	var_path     string
+	env_template string
+	watch        bool
+	delete       bool
 }
 
 var fsArgs fsFlags
@@ -24,7 +24,7 @@ func init() {
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.base_dir, "base-dir", "./", "Path to the base directory")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.path, "path", "**/*.nomad", "glob pattern relative to the base-dir")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the base-dir")
-	bootstrapFsCmd.Flags().StringVar(&fsArgs.env_prefix, "env-prefix", "env:", "prefix used for environment variable replacement")
+	bootstrapFsCmd.Flags().StringVar(&fsArgs.env_template, "env-template", "<<\\$env\\(([A-Z0-9_]+)\\)>>", "template used for environment variable replacement")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.watch, "watch", false, "Enable watch mode")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.delete, "delete", false, "Enable delete missing jobs")
 }
@@ -35,11 +35,11 @@ var bootstrapFsCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:      fsArgs.path,
-			VarPath:   fsArgs.var_path,
-			EnvPrefix: fsArgs.env_prefix,
-			Watch:     fsArgs.watch,
-			Delete:    fsArgs.delete,
+			Path:        fsArgs.path,
+			VarPath:     fsArgs.var_path,
+			EnvTemplate: fsArgs.env_template,
+			Watch:       fsArgs.watch,
+			Delete:      fsArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				fs := osfs.New(fsArgs.base_dir)
 				return fs, nil

--- a/cmd/bootstrap_fs.go
+++ b/cmd/bootstrap_fs.go
@@ -9,11 +9,12 @@ import (
 )
 
 type fsFlags struct {
-	base_dir string
-	path     string
-	var_path string
-	watch    bool
-	delete   bool
+	base_dir       string
+	path           string
+	var_path       string
+	var_env_prefix string
+	watch          bool
+	delete         bool
 }
 
 var fsArgs fsFlags
@@ -23,6 +24,7 @@ func init() {
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.base_dir, "base-dir", "./", "Path to the base directory")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.path, "path", "**/*.nomad", "glob pattern relative to the base-dir")
 	bootstrapFsCmd.Flags().StringVar(&fsArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the base-dir")
+	bootstrapFsCmd.Flags().StringVar(&fsArgs.var_env_prefix, "var-env-prefix", "env:", "prefix used for environment variable replacement")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.watch, "watch", false, "Enable watch mode")
 	bootstrapFsCmd.Flags().BoolVar(&fsArgs.delete, "delete", false, "Enable delete missing jobs")
 }
@@ -33,10 +35,11 @@ var bootstrapFsCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:    fsArgs.path,
-			VarPath: fsArgs.var_path,
-			Watch:   fsArgs.watch,
-			Delete:  fsArgs.delete,
+			Path:         fsArgs.path,
+			VarPath:      fsArgs.var_path,
+			VarEnvPrefix: fsArgs.var_env_prefix,
+			Watch:        fsArgs.watch,
+			Delete:       fsArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				fs := osfs.New(fsArgs.base_dir)
 				return fs, nil

--- a/cmd/bootstrap_git.go
+++ b/cmd/bootstrap_git.go
@@ -15,16 +15,17 @@ import (
 )
 
 type gitFlags struct {
-	url         string
-	branch      string
-	path        string
-	var_path    string
-	username    string
-	password    string
-	sshkey      string
-	sshinsecure bool
-	watch       bool
-	delete      bool
+	url            string
+	branch         string
+	path           string
+	var_path       string
+	var_env_prefix string
+	username       string
+	password       string
+	sshkey         string
+	sshinsecure    bool
+	watch          bool
+	delete         bool
 }
 
 var gitArgs gitFlags
@@ -35,6 +36,7 @@ func init() {
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.branch, "branch", "main", "git branch")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.path, "path", "**/*.nomad", "glob pattern relative to the repository root")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the repository root")
+	bootstrapGitCmd.Flags().StringVar(&fsArgs.var_env_prefix, "var-env-prefix", "env:", "prefix used for environment variable replacement")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.username, "username", "git", "SSH username")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.password, "password", "", "SSH private key password")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.sshkey, "ssh-key", "", "SSH private key")
@@ -50,10 +52,11 @@ var bootstrapGitCmd = &cobra.Command{
 	// Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:    gitArgs.path,
-			VarPath: gitArgs.var_path,
-			Watch:   gitArgs.watch,
-			Delete:  gitArgs.delete,
+			Path:         gitArgs.path,
+			VarPath:      gitArgs.var_path,
+			VarEnvPrefix: fsArgs.var_env_prefix,
+			Watch:        gitArgs.watch,
+			Delete:       gitArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				repositoryURL, err := url.Parse(gitArgs.url)
 				if err != nil {

--- a/cmd/bootstrap_git.go
+++ b/cmd/bootstrap_git.go
@@ -36,7 +36,7 @@ func init() {
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.branch, "branch", "main", "git branch")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.path, "path", "**/*.nomad", "glob pattern relative to the repository root")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the repository root")
-	bootstrapGitCmd.Flags().StringVar(&fsArgs.env_prefix, "env-prefix", "env:", "prefix used for environment variable replacement")
+	bootstrapGitCmd.Flags().StringVar(&fsArgs.env_template, "env-template", "<<\\$env\\(([A-Z0-9_]+)\\)>>", "template used for environment variable replacement")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.username, "username", "git", "SSH username")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.password, "password", "", "SSH private key password")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.sshkey, "ssh-key", "", "SSH private key")
@@ -52,11 +52,11 @@ var bootstrapGitCmd = &cobra.Command{
 	// Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:      gitArgs.path,
-			VarPath:   gitArgs.var_path,
-			EnvPrefix: fsArgs.env_prefix,
-			Watch:     gitArgs.watch,
-			Delete:    gitArgs.delete,
+			Path:        gitArgs.path,
+			VarPath:     gitArgs.var_path,
+			EnvTemplate: fsArgs.env_template,
+			Watch:       gitArgs.watch,
+			Delete:      gitArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				repositoryURL, err := url.Parse(gitArgs.url)
 				if err != nil {

--- a/cmd/bootstrap_git.go
+++ b/cmd/bootstrap_git.go
@@ -15,17 +15,17 @@ import (
 )
 
 type gitFlags struct {
-	url            string
-	branch         string
-	path           string
-	var_path       string
-	var_env_prefix string
-	username       string
-	password       string
-	sshkey         string
-	sshinsecure    bool
-	watch          bool
-	delete         bool
+	url         string
+	branch      string
+	path        string
+	var_path    string
+	env_prefix  string
+	username    string
+	password    string
+	sshkey      string
+	sshinsecure bool
+	watch       bool
+	delete      bool
 }
 
 var gitArgs gitFlags
@@ -36,7 +36,7 @@ func init() {
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.branch, "branch", "main", "git branch")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.path, "path", "**/*.nomad", "glob pattern relative to the repository root")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.var_path, "var-path", "**/*.vars.yml", "var glob pattern relative to the repository root")
-	bootstrapGitCmd.Flags().StringVar(&fsArgs.var_env_prefix, "var-env-prefix", "env:", "prefix used for environment variable replacement")
+	bootstrapGitCmd.Flags().StringVar(&fsArgs.env_prefix, "env-prefix", "env:", "prefix used for environment variable replacement")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.username, "username", "git", "SSH username")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.password, "password", "", "SSH private key password")
 	bootstrapGitCmd.Flags().StringVar(&gitArgs.sshkey, "ssh-key", "", "SSH private key")
@@ -52,11 +52,11 @@ var bootstrapGitCmd = &cobra.Command{
 	// Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return reconcile.Run(reconcile.ReconcileOptions{
-			Path:         gitArgs.path,
-			VarPath:      gitArgs.var_path,
-			VarEnvPrefix: fsArgs.var_env_prefix,
-			Watch:        gitArgs.watch,
-			Delete:       gitArgs.delete,
+			Path:      gitArgs.path,
+			VarPath:   gitArgs.var_path,
+			EnvPrefix: fsArgs.env_prefix,
+			Watch:     gitArgs.watch,
+			Delete:    gitArgs.delete,
 			Fs: func() (billy.Filesystem, error) {
 				repositoryURL, err := url.Parse(gitArgs.url)
 				if err != nil {

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -19,12 +19,12 @@ import (
 )
 
 type ReconcileOptions struct {
-	Path         string
-	VarPath      string
-	VarEnvPrefix string
-	Watch        bool
-	Delete       bool
-	Fs           func() (billy.Filesystem, error)
+	Path      string
+	VarPath   string
+	EnvPrefix string
+	Watch     bool
+	Delete    bool
+	Fs        func() (billy.Filesystem, error)
 }
 
 func Run(opts ReconcileOptions) error {
@@ -93,12 +93,12 @@ func Run(opts ReconcileOptions) error {
 			// Update variable
 			fmt.Printf("Updating vars [%s]\n", newVariable.Path)
 
-			if opts.VarEnvPrefix != "" {
-				// Update all items that prefix with VarEnvPrefix with environment variables.
-				// If the environment variable doesn't exist value will be set to empty string when updating the variable.
+			if opts.EnvPrefix != "" {
+				// Update all items that prefix with EnvPrefix with environment variables.
+				// If the environment variable doesn't exist, value will be set to empty string when updating the variable.
 				for key, value := range newVariable.Items {
-					if strings.HasPrefix(value, opts.VarEnvPrefix) {
-						envVar := strings.TrimPrefix(value, opts.VarEnvPrefix)
+					if strings.HasPrefix(value, opts.EnvPrefix) {
+						envVar := strings.TrimPrefix(value, opts.EnvPrefix)
 						envValue := os.Getenv(envVar)
 						fmt.Printf("Updating vars [%s][%s] with environment variable [%s]\n", newVariable.Path, key, envVar)
 						newVariable.Items[key] = envValue

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -18,11 +19,12 @@ import (
 )
 
 type ReconcileOptions struct {
-	Path    string
-	VarPath string
-	Watch   bool
-	Delete  bool
-	Fs      func() (billy.Filesystem, error)
+	Path         string
+	VarPath      string
+	VarEnvPrefix string
+	Watch        bool
+	Delete       bool
+	Fs           func() (billy.Filesystem, error)
 }
 
 func Run(opts ReconcileOptions) error {
@@ -90,6 +92,20 @@ func Run(opts ReconcileOptions) error {
 
 			// Update variable
 			fmt.Printf("Updating vars [%s]\n", newVariable.Path)
+
+			if opts.VarEnvPrefix != "" {
+				// Update all items that prefix with VarEnvPrefix with environment variables.
+				// If the environment variable doesn't exist value will be set to empty string when updating the variable.
+				for key, value := range newVariable.Items {
+					if strings.HasPrefix(value, opts.VarEnvPrefix) {
+						envVar := strings.TrimPrefix(value, opts.VarEnvPrefix)
+						envValue := os.Getenv(envVar)
+						fmt.Printf("Updating vars [%s][%s] with environment variable [%s]\n", newVariable.Path, key, envVar)
+						newVariable.Items[key] = envValue
+					}
+				}
+			}
+
 			err = client.UpdateVariable(&newVariable)
 			if err != nil {
 				return err


### PR DESCRIPTION
~~This introduces a new flag called `--var-env-prefix` which defaults to `env:`. This allows us to replace variables with environment variables allowing us to store the secret in CI or have dynamic values without writing tools.~~ I have updated the README.md with links to http://dotenvx.com which even allows to check encrypted .env files in the source control. While there are other tools such as [sops](https://github.com/getsops/sops), [git-secret](https://sobolevn.me/git-secret/), [dotenvx](http://dotenvx.com) is probably the most simple one for anyone to get started.

[update]
Thinking more about this I updated the code to now use `--env-template` which uses `<<$env(VARIABLE)>>` prefix instead of `env:`. Right now I loop through the items in variables files, but in the future we could use the same template to expand to other files such as nomad jobs or even the entire variables file. Tried to use a template syntax that doesn't conflict with nomad variables. I'm using `$env()` to allow opportunities in the future to add support for other sources.
